### PR TITLE
Adding headers to request

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 var exec = require('child_process').exec;
-var parseWrk = require('./lib/parseWrk')
+var parseWrk = require('./lib/parseWrk');
 
 function wrk(opts, callback) {
-
-  var cmd = opts.path || 'wrk';
+    var cmd = opts.path || 'wrk';
 
   if (opts.threads)
     cmd += ' -t' + opts.threads;
@@ -17,7 +16,10 @@ function wrk(opts, callback) {
     cmd += ' --timeout ' + opts.timeout;
   if (opts.printLatency)
     cmd += ' --latency ';
-  cmd += ' ' + opts.url;
+  if(opts.headers && opts.headers.length)
+    cmd += ' -H ' + opts.headers.join(' -H ');
+
+    cmd += ' ' + opts.url;
 
   var child = exec(cmd, function(error, stdout, stderr) {
     if (opts.debug) {
@@ -47,4 +49,4 @@ module.exports.co = function(opts) {
   return function(callback) {
     wrk(opts, callback);
   }
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec;
 var parseWrk = require('./lib/parseWrk');
+var util = require("util");
 
 function wrk(opts, callback) {
   var cmd = opts.path || 'wrk';
@@ -17,10 +18,9 @@ function wrk(opts, callback) {
   if (opts.printLatency)
     cmd += ' --latency ';
   if (opts.headers) {
-    for (var key in opts.headers) {
-      if (opts.headers.hasOwnProperty(key))
-        cmd += ' -H ' + `'${key}: ${opts.headers[key]}'`;
-    }
+    Object.keys(opts.headers).forEach(function(key) {
+      cmd += util.format(' -H  \'%s: %s\'', key,  opts.headers[key]);
+    })
   }
 
   cmd += ' ' + opts.url;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var exec = require('child_process').exec;
 var parseWrk = require('./lib/parseWrk');
 
 function wrk(opts, callback) {
-    var cmd = opts.path || 'wrk';
+  var cmd = opts.path || 'wrk';
 
   if (opts.threads)
     cmd += ' -t' + opts.threads;
@@ -16,10 +16,14 @@ function wrk(opts, callback) {
     cmd += ' --timeout ' + opts.timeout;
   if (opts.printLatency)
     cmd += ' --latency ';
-  if(opts.headers && opts.headers.length)
-    cmd += ' -H ' + opts.headers.join(' -H ');
+  if (opts.headers) {
+    for (var key in opts.headers) {
+      if (opts.headers.hasOwnProperty(key))
+        cmd += ' -H ' + `'${key}: ${opts.headers[key]}'`;
+    }
+  }
 
-    cmd += ' ' + opts.url;
+  cmd += ' ' + opts.url;
 
   var child = exec(cmd, function(error, stdout, stderr) {
     if (opts.debug) {


### PR DESCRIPTION
Added header support. Takes an object of key values in the `opts` parameter:

```
headers: {
    "Authorization": "foobar",
    "DNT": 0
}
```
Remember to escape quotes. 

**Note:** currently wrk does not support adding multiple header of the same type (last one set will win), see https://github.com/wg/wrk/issues/152.