### PR TITLE
Avoid double callback calling

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,23 +30,13 @@ function wrk(opts, callback) {
   var child = exec(cmd, function(error, stdout, stderr) {
     if (opts.debug) {
       console.log('stdout:\n', stdout);
-      console.log('stderr:\n', stderr);
+      console.error('stderr:\n', stderr);
     }
     if (error) {
       return callback(error);
     }
 
     callback(null, parseWrk(stdout));
-  });
-
-  child.on('close', function(code, signal) {
-    if (code === null) {
-      return callback(new Error('killed by signal: %s', signal));
-    }
-
-    if (code !== 0) {
-      return callback(new Error('died with exit code: %s', code));
-    }
   });
 }
 


### PR DESCRIPTION
No need to handle `close` event

From `exec` docu:
On error, error will be an instance of Error. The error.code property will be the exit code of the child process while error.signal will   be set to the signal that terminated the process. Any exit code other than 0 is considered to be an error.

Fix #8