### PR TITLE
add support passing through options to child_process.exec

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,12 @@ function wrk(opts, callback) {
     })
   }
 
+  // the caller may have requested that we pass options to the exec
+  const { execOptions={} } = opts
+
   cmd += ' ' + opts.url;
   opts.debug && console.log(cmd);
-  var child = exec(cmd, function(error, stdout, stderr) {
+  var child = exec(cmd, execOptions, function(error, stdout, stderr) {
     if (opts.debug) {
       stdout && console.log(stdout);
       stderr && console.error(stderr);


### PR DESCRIPTION
to improve support for wrk paths that have spaces, i propose that node-wrk support an `execOptions` optional input parameter. node-wrk will then pass this through to child_process.exec.

this allows callers to use the default `path: wrk` value assignment, and instead pass `execOptions: { cwd: '/path/with some/spaces' }`